### PR TITLE
Modul-Ordner in modman Datei

### DIFF
--- a/modman
+++ b/modman
@@ -1,4 +1,4 @@
-src/app/code/community/Flagbit app/code/community/Flagbit
+src/app/code/community/Flagbit/FilterUrls app/code/community/Flagbit/FilterUrls
 src/app/design/frontend/base/default/layout/* app/design/frontend/base/default/layout/
 src/app/etc/modules/* app/etc/modules
 src/shell/* shell


### PR DESCRIPTION
Hallo,

habe den Modulnamen mit in das modman Mapping aufgenommen, damit nicht der Namespace-Ordner, sondern der Modul-Ordner gesymlinked wird, da das sonst zu Problemen mit anderen Flagbit-Modulen die im gleichen Code-Pool+Namespace installiert sind.
