### PR TITLE
bugfix: remove empty array elements to avoid wrong links on removed filters

### DIFF
--- a/src/app/code/community/Flagbit/FilterUrls/Model/Catalog/Layer/Filter/Item.php
+++ b/src/app/code/community/Flagbit/FilterUrls/Model/Catalog/Layer/Filter/Item.php
@@ -117,7 +117,7 @@ class Flagbit_FilterUrls_Model_Catalog_Layer_Filter_Item extends Mage_Catalog_Mo
 
 
         ksort($filterUrlArray['filterUrl']);
-        $filterUrlString = implode('-', $filterUrlArray['filterUrl']);
+        $filterUrlString = implode('-', array_filter($filterUrlArray['filterUrl']));
 
         //replace url with category url
         if(Mage::registry('current_category') != null) {


### PR DESCRIPTION
when you have 3 or more filters and would like to remove one links are generated like:

http://yourdomain.com/category/filter1-filter2-/
http://yourdomain.com/category/filter1--filter3/

because there are still empty array elements left.
This fixes the bug and removes the empty elements from the array so that the links show up like:

http://yourdomain.com/category/filter1-filter2/
http://yourdomain.com/category/filter1-filter3/
