### PR TITLE
Fix Magento Enterprise URL issues

### DIFF
--- a/src/app/code/community/Flagbit/FilterUrls/Helper/Data.php
+++ b/src/app/code/community/Flagbit/FilterUrls/Helper/Data.php
@@ -68,15 +68,20 @@ class Flagbit_FilterUrls_Helper_Data extends Mage_Catalog_Helper_Product_Url
         return $string;
     }
 
+    /**
+     * Get the configured URL suffix
+     *
+     * @return string
+     */
     public function getUrlSuffix()
     {
-        $suffix = '';
-        if(Mage::helper('core')->isModuleEnabled('Enterprise_Catalog'))
-        {
-            $suffix .= '.';
+        $suffix = Mage::getStoreConfig('catalog/seo/category_url_suffix');
+        if (Mage::helper('core')->isModuleEnabled('Enterprise_Catalog')
+            && substr($suffix, 0, 1) !== '.') {
+            $suffix = '.' . $suffix;
         }
-        $suffix .= Mage::getStoreConfig('catalog/seo/category_url_suffix');
 
         return $suffix;
     }
+
 }


### PR DESCRIPTION
The helper method `getUrlSuffix()` is prefixing the URL suffix with a `.`, however this dot is being added in the core config when upgrading to a newer version of EE and now I am getting two dots out of this method. So I added a check if there isn't a dot yet, before it is added.