### PR TITLE
Update the composer constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "magento_connect":{
             "channel":"community",
             "php_min":"5.3.0",
-            "php_max":"6.0.0",
+            "php_max":"7.3.0",
             "stability":"beta",
             "content":[
                 {

--- a/modman
+++ b/modman
@@ -2,4 +2,3 @@ src/app/code/community/Flagbit/FilterUrls app/code/community/Flagbit/FilterUrls
 src/app/design/frontend/base/default/layout/* app/design/frontend/base/default/layout/
 src/app/etc/modules/* app/etc/modules
 src/shell/* shell
-packager/src/shell/* shell


### PR DESCRIPTION
Hello,

I installed your module on my project : Magento edition and version 1.11.2 Enterprise
and PHP version 7.2.8. 
And during the installation the composer install has returned an error because my PHP version is not compatible with the max version defined in the composer.json. 
I upgraded this limit and check your module in my Magento project : your module works perfectly under PHP 7.2.8.
So I would suggest this PR.